### PR TITLE
Fix install link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Enhanced fork of [gitricko/sonarless](https://github.com/gitricko/sonarless) wit
 
 ```bash
 # Install the enhanced CLI
-curl -s "https://raw.githubusercontent.com/VIDADv1/scanwise/main/install.sh" | bash
+curl -s "https://raw.githubusercontent.com/VIDADv1/scanwise/main/scripts/install.sh" | bash
 ```
 
 ### GitHub Actions


### PR DESCRIPTION
Hi there! The project has a great potential and probably I will test it for my research

But now the install link returns `404: Not Found` because it refers to incorrect path of _install.sh_

Let's fix it and improve user experience